### PR TITLE
Changes needed for Fedora 21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ go-bench:
 	$(call go_build,go test -bench=".*" novmm)
 	$(call go_build,go test -bench=".*" noguest)
 go-fmt:
-	$(call go_build,gofmt -l=true -w=true -tabs=false -tabwidth=4 src/novmm/$*)
-	$(call go_build,gofmt -l=true -w=true -tabs=false -tabwidth=4 src/noguest/$*)
+	$(call go_build,gofmt -l=true -w=true  src/novmm/$*)
+	$(call go_build,gofmt -l=true -w=true  src/noguest/$*)
 
 test: go-test
 .PHONY: test

--- a/src/novmm/loader/linux_setup.go
+++ b/src/novmm/loader/linux_setup.go
@@ -21,9 +21,11 @@ package loader
 #include <string.h>
 
 #ifdef __x86_64__
-#include <x86_64-linux-gnu/asm/bootparam.h>
+//#include <x86_64-linux-gnu/asm/bootparam.h>
+#include <asm/bootparam.h>
 #else
-#include <i386-linux-gnu/asm/bootparam.h>
+//#include <i386-linux-gnu/asm/bootparam.h>
+#include <asm/bootparam.h>
 #endif
 
 // E820 codes.
@@ -69,75 +71,75 @@ static inline void set_header(
 import "C"
 
 import (
-    "novmm/machine"
-    "novmm/platform"
-    "unsafe"
+	"novmm/machine"
+	"novmm/platform"
+	"unsafe"
 )
 
 func SetupLinuxBootParams(
-    model *machine.Model,
-    boot_params_data []byte,
-    orig_boot_params_data []byte,
-    cmdline_addr platform.Paddr,
-    initrd_addr platform.Paddr,
-    initrd_len uint64) error {
+	model *machine.Model,
+	boot_params_data []byte,
+	orig_boot_params_data []byte,
+	cmdline_addr platform.Paddr,
+	initrd_addr platform.Paddr,
+	initrd_len uint64) error {
 
-    // Grab a reference to our boot params struct.
-    boot_params := (*C.struct_boot_params)(unsafe.Pointer(&boot_params_data[0]))
+	// Grab a reference to our boot params struct.
+	boot_params := (*C.struct_boot_params)(unsafe.Pointer(&boot_params_data[0]))
 
-    // The setup header.
-    // First step is to copy the existing setup_header
-    // out of the given kernel image. We copy only the
-    // header, and not the rest of the setup page.
-    setup_start := 0x01f1
-    setup_end := 0x0202 + int(orig_boot_params_data[0x0201])
-    if setup_end > platform.PageSize {
-        return InvalidSetupHeader
-    }
-    C.memcpy(
-        unsafe.Pointer(&boot_params_data[setup_start]),
-        unsafe.Pointer(&orig_boot_params_data[setup_start]),
-        C.size_t(setup_end-setup_start))
+	// The setup header.
+	// First step is to copy the existing setup_header
+	// out of the given kernel image. We copy only the
+	// header, and not the rest of the setup page.
+	setup_start := 0x01f1
+	setup_end := 0x0202 + int(orig_boot_params_data[0x0201])
+	if setup_end > platform.PageSize {
+		return InvalidSetupHeader
+	}
+	C.memcpy(
+		unsafe.Pointer(&boot_params_data[setup_start]),
+		unsafe.Pointer(&orig_boot_params_data[setup_start]),
+		C.size_t(setup_end-setup_start))
 
-    // Setup our BIOS memory map.
-    // NOTE: We have to do this via C bindings. This is really
-    // annoying, but basically because of the unaligned structures
-    // in the struct_boot_params, the Go code generated here is
-    // actually *incompatible* with the actual C layout.
+	// Setup our BIOS memory map.
+	// NOTE: We have to do this via C bindings. This is really
+	// annoying, but basically because of the unaligned structures
+	// in the struct_boot_params, the Go code generated here is
+	// actually *incompatible* with the actual C layout.
 
-    // First, the count.
-    C.e820_set_count(boot_params, C.int(len(model.MemoryMap)))
+	// First, the count.
+	C.e820_set_count(boot_params, C.int(len(model.MemoryMap)))
 
-    // Then, fill out the region information.
-    for index, region := range model.MemoryMap {
+	// Then, fill out the region information.
+	for index, region := range model.MemoryMap {
 
-        var memtype C.int
-        switch region.MemoryType {
-        case machine.MemoryTypeUser:
-            memtype = C.E820Ram
-        case machine.MemoryTypeReserved:
-            memtype = C.E820Reserved
-        case machine.MemoryTypeSpecial:
-            memtype = C.E820Reserved
-        case machine.MemoryTypeAcpi:
-            memtype = C.E820Acpi
-        }
+		var memtype C.int
+		switch region.MemoryType {
+		case machine.MemoryTypeUser:
+			memtype = C.E820Ram
+		case machine.MemoryTypeReserved:
+			memtype = C.E820Reserved
+		case machine.MemoryTypeSpecial:
+			memtype = C.E820Reserved
+		case machine.MemoryTypeAcpi:
+			memtype = C.E820Acpi
+		}
 
-        C.e820_set_region(
-            boot_params,
-            C.int(index),
-            C.__u64(region.Start),
-            C.__u64(region.Size),
-            C.__u8(memtype))
-    }
+		C.e820_set_region(
+			boot_params,
+			C.int(index),
+			C.__u64(region.Start),
+			C.__u64(region.Size),
+			C.__u8(memtype))
+	}
 
-    // Set necessary setup header bits.
-    C.set_header(
-        boot_params,
-        C.__u64(initrd_addr),
-        C.__u64(initrd_len),
-        C.__u64(cmdline_addr))
+	// Set necessary setup header bits.
+	C.set_header(
+		boot_params,
+		C.__u64(initrd_addr),
+		C.__u64(initrd_len),
+		C.__u64(cmdline_addr))
 
-    // All done!
-    return nil
+	// All done!
+	return nil
 }


### PR DESCRIPTION
Hi
This is just a FYI not a real pull request.

I am using Fedora 21 with go 1.3.3. Looks like gofmt doesn't support "-tabs=false -tabwidth=4 " syntax anymore. Also bootparam.h is in /usr/include/asm/ not /usr/include/x86_64-linux-gnu/asm/.
