### PR TITLE
Change python shebang to use python2

### DIFF
--- a/scripts/novm
+++ b/scripts/novm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
Some distributions use python3 as default python,
so move shebang to `env python2`.

Signed-off-by: Yang Bai hamo.by@gmail.com

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/novm/16)

<!-- Reviewable:end -->
