### PR TITLE
Make modules dir before copy modules into it

### DIFF
--- a/lib/novm/libexec/mkinitramfs
+++ b/lib/novm/libexec/mkinitramfs
@@ -36,7 +36,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Create base directory structure.
-mkdir -p $WDIR/{bin,dev,lib/firmware,run,sbin,sys,proc}
+mkdir -p $WDIR/{bin,dev,lib/firmware,lib/modules/$KERNEL_VERSION,run,sbin,sys,proc}
 mkdir -p $WDIR/etc/{modprobe.d,udev/rules.d}
 touch $WDIR/etc/modprobe.d/modprobe.conf
 ln -s lib $WDIR/lib64


### PR DESCRIPTION
On my machine (with ArchLinux), when I do "mkkernel" I got an error said that $WDIR/lib/modules/$KERNEL_VERSION is not a dir. So create it before copy modules into it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/novm/18)

<!-- Reviewable:end -->
