### PR TITLE
Make sure DEBIAN directory has correct permissions during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ deb: dist
 	@rm -rf debbuild && mkdir -p debbuild
 	@rsync -ruav packagers/DEBIAN debbuild
 	@rsync -ruav dist/ debbuild
+	@chmod 755 debbuild/DEBIAN
 	@sed -i "s/VERSION/$(VERSION)-$(RELEASE)/" debbuild/DEBIAN/control
 	@sed -i "s/MAINTAINER/$(MAINTAINER)/" debbuild/DEBIAN/control
 	@sed -i "s/ARCHITECTURE/$(DEB_ARCH)/" debbuild/DEBIAN/control


### PR DESCRIPTION
Git appears to check out directories with permission 750. Dpkg
requires the DEBIAN directory to be accessible by everyone.
