### PR TITLE
Fix pkg-info's project URL

### DIFF
--- a/pkg-info
+++ b/pkg-info
@@ -1,4 +1,4 @@
 # Basic package information.
 MAINTAINER ?= Adin Scannell <ascannell@google.com>
 SUMMARY ?= A high-performance, next-generation hypervisor written in Go.
-URL ?= http://code.google.com/p/novm/
+URL ?= https://github.com/google/novm


### PR DESCRIPTION
When trying to access http://code.google.com/p/novm/, 404 is returned. It seems the project at code.google.com is abandonded in favour of hosting it at GitHub.

I have already signed the CLA.
