### PR TITLE
[RFC] Move instance meta file under  dir and output novmm log

### DIFF
--- a/novm/db.py
+++ b/novm/db.py
@@ -52,6 +52,11 @@ class Nodb(object):
     def file(self, obj_id, *args):
         return os.path.join(self._root, obj_id, *args)
 
+    def dirs(self):
+        # List all dirs under _root.
+        entries = os.listdir(self._root)
+        return [x for x in entries if os.path.isdir(self.file(x))]
+
     def list(self):
         # We store all data in the given directory.
         # All entries are simply stored as json files.
@@ -59,7 +64,7 @@ class Nodb(object):
         return [x[0] for x in entries if x[1] == '.json']
 
     def show(self):
-        keys = self.list()
+        keys = self.dirs()
         result = {}
         for key in keys:
             try:
@@ -80,8 +85,12 @@ class Nodb(object):
 
     def get(self, obj_id=None, **kwargs):
         obj_id = self.find(obj_id=obj_id, **kwargs)
-        with open(self.file("%s.json" % obj_id), 'r') as inf:
-            return json.load(inf)
+        if (os.path.exists(self.file("%s.json" % obj_id))):
+            with open(self.file("%s.json" % obj_id), 'r') as inf:
+                return json.load(inf)
+        else:
+            with open(self.file(obj_id, "%s.json" % obj_id)) as inf:
+                return json.load(inf)
 
     def remove(self, obj_id=None, **kwargs):
         obj_id = self.find(obj_id=obj_id, **kwargs)

--- a/novm/manager.py
+++ b/novm/manager.py
@@ -145,7 +145,7 @@ class NovmManager(object):
         # (This is done as a callback since run() may
         # fork, etc. and we may need to do certain setup
         # routines within the novmm process proper.
-        def state(output):
+        def state(output, my_instance):
             devices = []
 
             # Always add basic devices.
@@ -228,7 +228,7 @@ class NovmManager(object):
                 index=1+len(nics)+len(disks),
                 pci=not(nopci),
                 tag="root",
-                tempdir=self._instances.file(str(os.getpid())),
+                tempdir=my_instance.file("writable"),
                 read=read,
                 write=write))
 
@@ -336,10 +336,14 @@ class NovmManager(object):
         try:
             args = ["novmm"]
 
+            # It's time to create my instance info dir.
+            my_instance = db.Nodb(
+                self._instances.file(str(os.getpid())))
+
             # Provide our state by dumping to a temporary file.
             state_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
             os.remove(state_file.name)
-            state_args, metadata = state(state_file)
+            state_args, metadata = state(state_file, my_instance)
             state_file.seek(0, 0)
 
             # Keep the descriptor.
@@ -359,8 +363,12 @@ class NovmManager(object):
             # Add extra (debugging) arguments.
             args.extend(["-%s" % x for x in vmmopt])
 
+            # Add log file if not nofork.
+            if not nofork:
+                args.extend(["-logfile=%s" % my_instance.file("%s.log" % str(os.getpid()))])
+
             # Add our metadata to the registry.
-            self._instances.add(str(os.getpid()), metadata)
+            my_instance.add(str(os.getpid()), metadata)
             utils.cleanup(self._instances.remove, str(os.getpid()))
 
             # Close off final descriptors.

--- a/src/novmm/main.go
+++ b/src/novmm/main.go
@@ -47,6 +47,7 @@ var cmdline = flag.String("cmdline", "", "linux command line")
 var system_map = flag.String("sysmap", "", "kernel symbol map")
 
 // Debug parameters.
+var logfile = flag.String("logfile", "", "log output file path")
 var step = flag.Bool("step", false, "step instructions")
 var trace = flag.Bool("trace", false, "trace kernel symbols on exit")
 var debug = flag.Bool("debug", false, "devices start debugging")
@@ -144,6 +145,15 @@ func main() {
 
 	// Parse all command line options.
 	flag.Parse()
+
+	if *logfile != "" {
+		f, err := os.Create(*logfile)
+		if err != nil {
+			utils.Die(err)
+		}
+		defer f.Close()
+		log.SetOutput(f)
+	}
 
 	// Are we doing a special restart?
 	// This will STOP the current process, and


### PR DESCRIPTION
This patchset first moves all one instance related file from .novm/instances/ to .novm/instances/$PID/, including meta file, the writable dir (rename from $PID to writable) and a new log file output from novmm named novmm.log.

Then it enables novmm to output its log to the file .novm/instances/$PID/novmm.log, this will really help debugging.

Now `novm list` function is broken since I changed the dir structure. Will push next commit to fix it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/novm/25)

<!-- Reviewable:end -->
