### PR TITLE
[master] Tiny fix. (1.missing "import os" in block.py 2.parameter name t...

### DIFF
--- a/novm/block.py
+++ b/novm/block.py
@@ -14,6 +14,7 @@
 """
 Block device functions.
 """
+import os
 from . import virtio
 
 class Disk(virtio.Driver):

--- a/novm/shell.py
+++ b/novm/shell.py
@@ -65,7 +65,7 @@ class NovmShell(object):
 
             Available options are:
 
-            file=filename         Set the backing file (raw).
+            filename=filename     Set the backing file (raw).
             dev=vda               Set the device name.
             debug=true            Enable debugging.
 


### PR DESCRIPTION
Tiny fix. (1.missing "import os" in block.py 2.parameter name typo of "--disk" in shell.py)

[issue 1]
$sudo novm --debug create --name test --nofork --disk file=/var/lib/libvirt/images/alice.img,dev=vda,debug=true

Traceback (most recent call last):
  File "./novm/cli.py", line 203, in main
    result = fn(*built_args)
  ......
  File "./novm/block.py", line 41, in create
    "fd": os.dup(f.fileno()),
NameError: global name 'os' is not defined

Missing `import os` here.

---

After fix issue1, issue2 occur:
[issue 2]
$sudo novm --debug create --name test --nofork --disk file=/var/lib/libvirt/images/rhel7.qcow2,dev=vda,debug=true

Traceback (most recent call last):
  File "/usr/bin/../lib/novm/python/novm/cli.py", line 203, in main
    result = fn(_built_args)
  ......
  File "/usr/bin/../lib/novm/python/novm/virtio.py", line 65, in create
    *_kwargs)
TypeError: create() got an unexpected keyword argument 'file'

---

```
    Disk definitions are provided as --disk [opt=val],...

        Available options are:

        file=filename     Set the backing file (raw). 
        dev=vda               Set the device name.
        debug=true            Enable debugging.
```

---

The real parameter in block.py is `filename`, but the description in shell.py is `file`.
