### PR TITLE
Force pickle.dump uses protocol 2

### DIFF
--- a/novm/manager.py
+++ b/novm/manager.py
@@ -383,8 +383,8 @@ class NovmManager(object):
         except:
             if not nofork:
                 # Write our exception.
-                w = os.fdopen(w_pipe, 'w')
-                pickle.dump(sys.exc_info()[:2], w)
+                w = os.fdopen(w_pipe, 'wb')
+                pickle.dump(sys.exc_info()[:2], w, 2)
                 w.close()
             # Raise in the main thread.
             exc_info = sys.exc_info()


### PR DESCRIPTION
with python2, pickle.dump use protocol 0 if not specified, protocol 0 is an ASCII protocol, current code works.
with python3, pickle.dump use protocol 3 if not specified, protocol 3 is a binary protocol, it requires the file to be written to is opened with "b", so python3 will complain that w is not opened with "b".

For better compatibility, force pickle.dump uses protocol 2, which is a binary protocol and open the pipe with "b", which will give us better performance. 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/novm/31)

<!-- Reviewable:end -->
