### PR TITLE
Fix data race of Ram struct and VirtioBufferSet map

### DIFF
--- a/src/novmm/machine/ram.go
+++ b/src/novmm/machine/ram.go
@@ -16,18 +16,24 @@ package machine
 
 import (
 	"math"
+	"sync"
 	"unsafe"
 )
 
 type Ram struct {
 	Data []byte `json:"data"`
+	lock sync.Mutex
 }
 
 func (ram *Ram) Size() int {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	return len(ram.Data)
 }
 
 func (ram *Ram) GrowTo(size int) {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	if size > len(ram.Data) {
 		missing := size - len(ram.Data)
 		new_bytes := make([]byte, missing, missing)
@@ -36,34 +42,50 @@ func (ram *Ram) GrowTo(size int) {
 }
 
 func (ram *Ram) Set8(offset int, data uint8) {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	ram.Data[offset] = byte(data)
 }
 
 func (ram *Ram) Get8(offset int) uint8 {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	return ram.Data[offset]
 }
 
 func (ram *Ram) Set16(offset int, data uint16) {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	*(*uint16)(unsafe.Pointer(&ram.Data[offset])) = data
 }
 
 func (ram *Ram) Get16(offset int) uint16 {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	return *(*uint16)(unsafe.Pointer(&ram.Data[offset]))
 }
 
 func (ram *Ram) Set32(offset int, data uint32) {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	*(*uint32)(unsafe.Pointer(&ram.Data[offset])) = data
 }
 
 func (ram *Ram) Get32(offset int) uint32 {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	return *(*uint32)(unsafe.Pointer(&ram.Data[offset]))
 }
 
 func (ram *Ram) Set64(offset int, data uint64) {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	*(*uint64)(unsafe.Pointer(&ram.Data[offset])) = data
 }
 
 func (ram *Ram) Get64(offset int) uint64 {
+	ram.lock.Lock()
+	defer ram.lock.Unlock()
 	return *(*uint64)(unsafe.Pointer(&ram.Data[offset]))
 }
 
@@ -119,4 +141,8 @@ func NewRam(size int) *Ram {
 	ram := new(Ram)
 	ram.Data = make([]byte, size, size)
 	return ram
+}
+
+func CreateRamFromBytes(bytes []byte) *Ram {
+	return &Ram{Data: bytes}
 }

--- a/src/novmm/machine/virtio_block.go
+++ b/src/novmm/machine/virtio_block.go
@@ -53,7 +53,7 @@ func (device *VirtioBlockDevice) processRequests(
 
 	for buf := range vchannel.incoming {
 
-		header := &Ram{buf.Map(0, 16)}
+		header := CreateRamFromBytes(buf.Map(0, 16))
 
 		// Legit?
 		if header.Size() < 16 {
@@ -69,7 +69,7 @@ func (device *VirtioBlockDevice) processRequests(
 		cmd_type := header.Get32(0)
 
 		// Our status byte.
-		status := &Ram{buf.Map(buf.Length()-1, 1)}
+		status := CreateRamFromBytes(buf.Map(buf.Length()-1, 1))
 
 		switch int(cmd_type) {
 		case VirtioBlockTIn:

--- a/src/novmm/machine/virtio_console.go
+++ b/src/novmm/machine/virtio_console.go
@@ -54,7 +54,7 @@ func (device *VirtioConsoleDevice) sendCtrl(
 
 	buf := <-device.Channels[2].incoming
 
-	header := &Ram{buf.Map(0, 8)}
+	header := CreateRamFromBytes(buf.Map(0, 8))
 
 	if header.Size() < 8 {
 		buf.length = 0
@@ -76,7 +76,7 @@ func (device *VirtioConsoleDevice) ctrlConsole(
 
 	for buf := range vchannel.incoming {
 
-		header := &Ram{buf.Map(0, 8)}
+		header := CreateRamFromBytes(buf.Map(0, 8))
 
 		// Legit?
 		if header.Size() < 8 {

--- a/src/novmm/machine/virtio_stream.go
+++ b/src/novmm/machine/virtio_stream.go
@@ -68,7 +68,7 @@ func (stream *VirtioStream) ReadN(size int) uint64 {
 	}
 
 	// Map our chunk.
-	ram := &Ram{stream.Map(stream.read_offset, size)}
+	ram := CreateRamFromBytes(stream.Map(stream.read_offset, size))
 
 	// Check for boundary.
 	if ram.Size() < size {
@@ -103,7 +103,7 @@ func (stream *VirtioStream) WriteN(size int, value uint64) {
 	}
 
 	// Map our chunk.
-	ram := &Ram{stream.Map(stream.write_offset, size)}
+	ram := CreateRamFromBytes(stream.Map(stream.write_offset, size))
 
 	// Check for boundary.
 	if ram.Size() < size {


### PR DESCRIPTION
On my computer, novm still can not work with go 1.4. When trying to debug this issue, go race detector found 2 race conditions.

The first one is Ram struct. And is fixed by commit 6f665f4. This is the output of go race detector:

> WARNING: DATA RACE
> Read by goroutine 16:
>   novmm/machine.(_MsiXDevice).ClearPending()
>       /home/hamo/workspace/novm/src/novmm/machine/msix.go:137 +0xa8
>   novmm/machine.(_MsiXDevice).SendInterrupt()
>       /home/hamo/workspace/novm/src/novmm/machine/msix.go:355 +0x1b0
>   novmm/machine.(_VirtioChannel).Interrupt()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:353 +0xe0
>   novmm/machine.(_VirtioChannel).ProcessOutgoing()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:328 +0x3a5
> 
> Previous write by goroutine 18:
>   novmm/machine.(_MsiXDevice).ClearPending()
>       /home/hamo/workspace/novm/src/novmm/machine/msix.go:138 +0x1a3
>   novmm/machine.(_MsiXDevice).SendInterrupt()
>       /home/hamo/workspace/novm/src/novmm/machine/msix.go:355 +0x1b0
>   novmm/machine.(_VirtioChannel).Interrupt()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:353 +0xe0
>   novmm/machine.(_VirtioChannel).ProcessOutgoing()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:328 +0x3a5
> 
> Goroutine 16 (running) created at:
>   novmm/machine.(_VirtioChannel).start()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:669 +0xed
>   novmm/machine.(_VirtioDevice).Attach()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:829 +0x261
>   novmm/machine.(_VirtioConsoleDevice).Attach()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio_console.go:187 +0x6c
>   novmm/machine.(_Model).CreateDevices()
>       /home/hamo/workspace/novm/src/novmm/machine/state.go:105 +0x1f5
>   main.main()
>       /home/hamo/workspace/novm/src/novmm/main.go:188 +0x90e
> 
> Goroutine 18 (running) created at:
>   novmm/machine.(_VirtioChannel).start()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:669 +0xed
>   novmm/machine.(_VirtioDevice).Attach()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:829 +0x261
>   novmm/machine.(_VirtioConsoleDevice).Attach()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio_console.go:187 +0x6c
>   novmm/machine.(_Model).CreateDevices()
>       /home/hamo/workspace/novm/src/novmm/machine/state.go:105 +0x1f5
>   main.main()
>       /home/hamo/workspace/novm/src/novmm/main.go:188 +0x90e

The second one is VirtioBufferSet map, and it is fixed by commit  7c7595d. Output of go race detector:

> WARNING: DATA RACE
> Write by goroutine 19:
>   runtime.mapassign1()
>       /build/go/src/go-1.4.1/src/runtime/hashmap.go:383 +0x0
>   novmm/machine.(_VirtioChannel).processOne()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:209 +0x78b
>   novmm/machine.(_VirtioChannel).consumeOne()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:249 +0x10d
>   novmm/machine.(*VirtioChannel).ProcessIncoming()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:287 +0x10f
> 
> Previous write by goroutine 18:
>   runtime.mapdelete()
>       /build/go/src/go-1.4.1/src/runtime/hashmap.go:495 +0x0
>   novmm/machine.(*VirtioChannel).ProcessOutgoing()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:339 +0x408
> 
> Goroutine 19 (running) created at:
>   novmm/machine.(_VirtioChannel).start()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:670 +0x107
>   novmm/machine.(_VirtioDevice).Attach()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:829 +0x261
>   novmm/machine.(_VirtioConsoleDevice).Attach()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio_console.go:187 +0x6c
>   novmm/machine.(_Model).CreateDevices()
>       /home/hamo/workspace/novm/src/novmm/machine/state.go:105 +0x1f5
>   main.main()
>       /home/hamo/workspace/novm/src/novmm/main.go:188 +0x90e
> 
> Goroutine 18 (running) created at:
>   novmm/machine.(_VirtioChannel).start()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:669 +0xed
>   novmm/machine.(_VirtioDevice).Attach()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio.go:829 +0x261
>   novmm/machine.(_VirtioConsoleDevice).Attach()
>       /home/hamo/workspace/novm/src/novmm/machine/virtio_console.go:187 +0x6c
>   novmm/machine.(_Model).CreateDevices()
>       /home/hamo/workspace/novm/src/novmm/machine/state.go:105 +0x1f5
>   main.main()
>       /home/hamo/workspace/novm/src/novmm/main.go:188 +0x90e

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/novm/35)

<!-- Reviewable:end -->
